### PR TITLE
fetch checkmark data and store it

### DIFF
--- a/frontend/src/views/leetcode/AllProblems/AllProblemTable.js
+++ b/frontend/src/views/leetcode/AllProblems/AllProblemTable.js
@@ -21,10 +21,14 @@ const AllProblemTable = ({
   onCheckboxChange,
   selectedCategories,
   editMode,
+  submittedProblems,
 }) => {
   const { uuid } = useContext(AuthContext);
   const [page, setPage] = useState(0);
   const [rowsPerPage, setRowsPerPage] = useState(5);
+
+  console.log('submitted', submittedProblems);
+  console.log('problem', data);
 
   const filteredData =
     filter === 'All'
@@ -124,8 +128,8 @@ const AllProblemTable = ({
                   {editMode && (
                     <TableCell padding='checkbox'>
                       <Checkbox
-                        checked={selectedCategories.includes(problem.name)}
-                        onChange={() => onCheckboxChange(problem.name)}
+                        checked={submittedProblems.includes(problem.id)}
+                        onChange={() => onCheckboxChange(problem.id)}
                       />
                     </TableCell>
                   )}

--- a/frontend/src/views/leetcode/Review/ProblemCategoriesTable.js
+++ b/frontend/src/views/leetcode/Review/ProblemCategoriesTable.js
@@ -55,13 +55,16 @@ const ProblemCategoriesTable = ({
       }
 
       const payload = { category: problemCategorySet };
-      await fetch(`${leetcodeAPIURL}/users/${uuid}/mark_type_for_review`, {
-        method: 'POST',
-        headers: {
-          'Content-Type': 'application/json',
-        },
-        body: JSON.stringify(payload),
-      });
+      await fetch(
+        `${leetcodeAPIURL}/users/${uuid}/problem/categories/review/submit`,
+        {
+          method: 'POST',
+          headers: {
+            'Content-Type': 'application/json',
+          },
+          body: JSON.stringify(payload),
+        }
+      );
       alert('Submitted successfully');
     } catch (error) {
       console.error('Error submitting data', error);

--- a/frontend/src/views/leetcode/Review/index.js
+++ b/frontend/src/views/leetcode/Review/index.js
@@ -32,11 +32,28 @@ const LeetcodeView = () => {
   const [loading, setLoading] = useState(true);
   const [problemsData, setProblemsData] = useState([]);
   const [view, setView] = useState('types');
+  const [selectedReviewCategories, setSelectedReviewCategories] = useState([]);
   const [selectedCategory, setSelectedCategory] = useState(null);
   const [selectedCategories, setSelectedCategories] = useState([]);
   const [editMode, setEditMode] = useState(false); // State to manage edit mode
 
   useEffect(() => {
+    const fetchSelectedReviewCategories = async (uuid) => {
+      setLoading(true);
+      try {
+        const response = await fetch(
+          `${leetcodeAPIURL}/users/${uuid}/problem/categories/review`
+        );
+        const data = await response.json();
+        console.log('Review Categories', data);
+        setSelectedReviewCategories(data);
+      } catch (error) {
+        console.error('Request failed:', error.message);
+      } finally {
+        setLoading(false);
+      }
+    };
+
     const fetchUsersLeetcodeQuestions = async (uuid) => {
       setLoading(true);
 
@@ -54,6 +71,7 @@ const LeetcodeView = () => {
 
     if (uuid) {
       fetchUsersLeetcodeQuestions(uuid);
+      fetchSelectedReviewCategories(uuid);
     }
   }, [uuid]);
 
@@ -70,11 +88,11 @@ const LeetcodeView = () => {
     setView('problems');
   };
 
-  const handleCheckboxChange = (type) => {
-    setSelectedCategories((prevSelectedTypes) =>
-      prevSelectedTypes.includes(type)
-        ? prevSelectedTypes.filter((t) => t !== type)
-        : [...prevSelectedTypes, type]
+  const handleCheckboxChange = (category) => {
+    setSelectedReviewCategories((prevSelectedCategories) =>
+      prevSelectedCategories.includes(category)
+        ? prevSelectedCategories.filter((c) => c !== category)
+        : [...prevSelectedCategories, category]
     );
   };
 
@@ -106,7 +124,8 @@ const LeetcodeView = () => {
       {view === 'types' && !loading && (
         <ProblemCategoriesTable
           problemCategories={problemCategories}
-          selectedCategories={selectedCategories}
+          selectedCategories={selectedReviewCategories}
+          // selectedReviewCategories={selectedReviewCategories}
           onTypeClick={handleTypeClick}
           onCheckboxChange={handleCheckboxChange}
           editMode={editMode}


### PR DESCRIPTION
# Pull Request Template

## Background
We don't load the checkmark data. Right now, it always loads as blank even if a user has previously check the box and submitted it

## Changes
For the problems that have been attempted already, fetch the user submissions from the backend and load the state of the checkmark box on the first load

For the problem categories that have been marked by review, fetch this from the backend and load the state of the checkmark box on the first load

## Screenshots

<img width="1440" alt="Screen Shot 2024-06-09 at 2 24 14 PM" src="https://github.com/WhatcomCodersDev/whatcomcoders_alumnidirectory/assets/19320103/02e097bb-3463-4ae1-8b59-8ff66c89a49b">
<img width="1440" alt="Screen Shot 2024-06-09 at 2 24 07 PM" src="https://github.com/WhatcomCodersDev/whatcomcoders_alumnidirectory/assets/19320103/456a4b63-708e-4435-b8f7-a7670058fc05">


## Testing
Ran frontend and backend

BTW - The filter for review categories is broken now, but will fix later 
cc: @tin159iop

